### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ To install rbenv-chefdk, clone this repository into the `$RBENV_ROOT/plugins`
 directory. This is usually `~/.rbenv/plugins` or `/usr/local/var/rbenv/plugins`
 if you follow the suggestion in [Homebrew](http://brew.sh/) on OS X.
 
+
+``` sh
+$ git clone https://github.com/docwhat/rbenv-chefdk.git $(rbenv root)/plugins/rbenv-chefdk
+```
+
 Then create an empty directory in `$RBENV_ROOT/versions` called `chefdk`:
 
 ``` sh


### PR DESCRIPTION
Makes the repo cloning process a little clearer for us n00bs, based on the ruby-build plugin's description of the git clone request for that plugin. I wasted some time figuring this out, why should others have to?

Uses $(rbenv root) in place of $RBENV_ROOT following the example of SeanSith in other current pull requests and because it's easier than specifying that it might be installed by Homebrew or might be installed by something else. I'm not married to that, but do think the clarification is useful.
